### PR TITLE
change a place of `import io` at onmt/io/TextDataset.py 

### DIFF
--- a/onmt/io/TextDataset.py
+++ b/onmt/io/TextDataset.py
@@ -2,7 +2,6 @@
 
 from collections import Counter
 from itertools import chain
-import io
 import codecs
 import sys
 
@@ -297,6 +296,7 @@ class ShardedTextCorpusIterator(object):
                         this iterator should align its step with.
         """
         try:
+            import io
             # The codecs module seems to have bugs with seek()/tell(),
             # so we use io.open().
             self.corpus = io.open(corpus_path, "r", encoding="utf-8")


### PR DESCRIPTION
* before: top of this python code
* after: constructor of class ShardedTextCorpusIterator(object).

In before state, an error `cannnot import name TextDataset` was caused at `onmt/IO.py`.

I thought that this is because `onmt/IO.py` and `onmt/TextDataset.py` tried to import each other.
※reference: [resolve ImportError: cannot import name (Japanese Qiita article)](https://qiita.com/puriketu99/items/a1347bf5200f095e486e)